### PR TITLE
Create manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ Schedule : `pip3 install schedule`
 
 ### Building an deployment package
 To create a deployable zip file, run the following script in the project's root directory: `./build_deployment.sh`
+
+### Setting up Duty Bot in a new Slack
+1. Navigate to https://api.slack.com/apps
+2. Click "Create New App"
+3. Select "From an app manifest"
+4. Pick the workspace you want to install Duty Bot to.
+5. Copy and paste the content from [manifest.yml](manifest.yml) into the "Enter app manifest below" textbox
+6. Click create!

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,38 @@
+display_information:
+  name: Duty Bot
+  description: Supporting Duty teams since 2019
+  background_color: "#1e4387"
+features:
+  bot_user:
+    display_name: Duty Bot
+    always_online: false
+  shortcuts:
+    - name: Update Duty Member
+      type: message
+      callback_id: update_duty_member
+      description: Updates the message to display the correct Duty Member
+oauth_config:
+  scopes:
+    bot:
+      - channels:join
+      - channels:read
+      - chat:write
+      - groups:write
+      - chat:write.public
+      - users:read.email
+      - users:read
+      - team:read
+      - mpim:read
+      - im:read
+      - im:write
+      - mpim:history
+      - mpim:write
+      - im:history
+      - commands
+settings:
+  interactivity:
+    is_enabled: true
+    request_url: https://vprxrywgdk.execute-api.us-west-2.amazonaws.com/default/updateDutyMessage
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false


### PR DESCRIPTION
This manifest helps easily install Duty Bot into a new Slack workspace.